### PR TITLE
fix: Provide higher rank to default OpenShift * Plugin profiles

### DIFF
--- a/gradle-plugin/openshift/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/gradle-plugin/openshift/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -17,6 +17,8 @@
 # tag::default[]
 # Default profile which is always activated
 - name: default
+  # This profile overrides the default profile in the Kubernetes plugin give a higher priority so it takes precedence
+  order: 10
   enricher:
     # The order given in "includes" is the order in which enrichers are called
     includes:
@@ -42,7 +44,6 @@
     - jkube-configmap-file
     - jkube-secret-file
 
-
     # -----------------------------------------
     # TODO: Document and verify enrichers below
     # Health checks
@@ -55,17 +56,19 @@
     - jkube-healthcheck-docker
     - jkube-healthcheck-webapp
     - jkube-healthcheck-micronaut
+
+    # Route exposure
+    - jkube-openshift-service-expose
+    # DeploymentConfigEnricher converts Deployment into DeploymentConfig
+    - jkube-openshift-deploymentconfig
+    - jkube-openshift-route
+    - jkube-openshift-project
+
     - jkube-prometheus
     - jkube-service-discovery
 
     # Value merge enrichers
     - jkube-container-env-java-options
-
-      # Route exposure
-    - jkube-openshift-service-expose
-    - jkube-openshift-route
-    - jkube-openshift-deploymentconfig
-    - jkube-openshift-project
 
     # Dependencies shouldn't be enriched anymore, therefore it's last in the list
     - jkube-dependency

--- a/openshift-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/openshift-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -12,11 +12,13 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-# Default profiles delivered with omp
+# Default profiles delivered with openshift-maven-plugin
 
 # tag::default[]
 # Default profile which is always activated
 - name: default
+  # This profile overrides the default profile in the Kubernetes plugin give a higher priority so it takes precedence
+  order: 10
   enricher:
     # The order given in "includes" is the order in which enrichers are called
     includes:
@@ -42,11 +44,6 @@
     - jkube-configmap-file
     - jkube-secret-file
 
-    # Route exposure
-    - jkube-openshift-service-expose
-    - jkube-openshift-route
-    - jkube-openshift-project
-
     # -----------------------------------------
     # TODO: Document and verify enrichers below
     # Health checks
@@ -59,14 +56,19 @@
     - jkube-healthcheck-docker
     - jkube-healthcheck-webapp
     - jkube-healthcheck-micronaut
+
+    # Route exposure
+    - jkube-openshift-service-expose
+    # DeploymentConfigEnricher converts Deployment into DeploymentConfig
+    - jkube-openshift-deploymentconfig
+    - jkube-openshift-route
+    - jkube-openshift-project
+
     - jkube-prometheus
     - jkube-service-discovery
 
     # Value merge enrichers
     - jkube-container-env-java-options
-
-    # DeploymentConfigEnricher converts Deployment into DeploymentConfig
-    - jkube-openshift-deploymentconfig
 
     # Dependencies shouldn't be enriched anymore, therefore it's last in the list
     - jkube-dependency


### PR DESCRIPTION
Since there are now different `default` profiles for OpenShift and Kubernetes,
we need to provide a higher order/rank to the one provided by OpenShift.
This one supposedly extends the one provided by Kubernetes.
This will allow users to add the two plugins to their projects and prevent
ClassLoader issues.
