### PR TITLE
refactor: use Config as argument instead of non-specific string

### DIFF
--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/BaseEnricher.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/BaseEnricher.java
@@ -158,10 +158,10 @@ public class BaseEnricher implements Enricher {
      * XML config.
      *
      * @param resourceConfig resource config from plugin configuration
-     * @param imagePullPolicyFromEnricherConfig ImagePullPolicy resolved from Enricher's configuration
+     * @param enricherConfig Enricher specific configuration for ImagePullPolicy
      * @return string as image pull policy
      */
-    protected String getImagePullPolicy(ResourceConfig resourceConfig, String imagePullPolicyFromEnricherConfig) {
+    protected String getImagePullPolicy(ResourceConfig resourceConfig, Configs.Config enricherConfig) {
         String imagePullPolicyFromProperty = getValueFromConfig(JKUBE_ENFORCED_IMAGE_PULL_POLICY, null);
         if (StringUtils.isNotBlank(imagePullPolicyFromProperty)) {
             return imagePullPolicyFromProperty;
@@ -169,6 +169,7 @@ public class BaseEnricher implements Enricher {
         if (resourceConfig != null && StringUtils.isNotBlank(resourceConfig.getImagePullPolicy())) {
             return resourceConfig.getImagePullPolicy();
         }
+        final String imagePullPolicyFromEnricherConfig = enricherConfig != null ? getConfig(enricherConfig) : null;
         if (StringUtils.isNotBlank(imagePullPolicyFromEnricherConfig)) {
             return imagePullPolicyFromEnricherConfig;
         }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ControllerViaPluginConfigurationEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ControllerViaPluginConfigurationEnricher.java
@@ -76,7 +76,7 @@ public class ControllerViaPluginConfigurationEnricher extends BaseEnricher {
         ResourceConfig xmlResourceConfig = getConfiguration().getResource();
         final ResourceConfig config = ResourceConfig.builder()
                 .controllerName(name)
-                .imagePullPolicy(getImagePullPolicy(xmlResourceConfig, getConfig(Config.PULL_POLICY)))
+                .imagePullPolicy(getImagePullPolicy(xmlResourceConfig, Config.PULL_POLICY))
                 .replicas(getReplicaCount(builder, xmlResourceConfig, Configs.asInt(getConfig(Config.REPLICA_COUNT))))
                 .build();
 

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultControllerEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultControllerEnricher.java
@@ -105,7 +105,7 @@ public class DefaultControllerEnricher extends BaseEnricher {
         .orElse(ResourceConfig.builder().build());
     ResourceConfig config = ResourceConfig.toBuilder(providedResourceConfig)
         .controllerName(getControllerName(providedResourceConfig, name))
-        .imagePullPolicy(getImagePullPolicy(providedResourceConfig, getConfig(Config.PULL_POLICY)))
+        .imagePullPolicy(getImagePullPolicy(providedResourceConfig, Config.PULL_POLICY))
         .replicas(getReplicaCount(builder, providedResourceConfig, Configs.asInt(getConfig(Config.REPLICA_COUNT))))
         .restartPolicy(providedResourceConfig.getRestartPolicy())
         .build();


### PR DESCRIPTION
## Description
Minor tweak that makes the purpose of BaseEnricher#getImagePullPolicy signature clearer by using the specific type instead of a generic String.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->